### PR TITLE
Feat/34 erase button

### DIFF
--- a/web-app/src/components/game/game.test.tsx
+++ b/web-app/src/components/game/game.test.tsx
@@ -32,12 +32,14 @@ function testSetup(puzzle: Puzzle) {
       };
     }, {}) as Record<Digit, HTMLElement>;
 
+  const erase = screen.getByRole("button", { name: /erase/i });
   const notes = screen.getByRole("button", { name: /notes/i });
   const undo = screen.getByRole("button", { name: /undo/i });
 
   return {
     cell,
     digit,
+    erase,
     notes,
     undo,
     screen,
@@ -512,5 +514,52 @@ describe("undo changes", () => {
     fireEvent.click(undo);
 
     expect(cell[2]).toHaveTextContent("57");
+  });
+});
+
+describe.only("erase toggled: off", () => {
+  test("should not erase given cell", () => {
+    const { cell, erase } = TEST_GAME;
+
+    fireEvent.click(erase);
+
+    fireEvent.click(cell[0]);
+
+    expect(cell[0]).toHaveTextContent("9");
+  });
+
+  test("should erase a proposed cell", () => {
+    const { cell, digit, erase } = TEST_GAME;
+
+    fireEvent.click(cell[1]);
+    fireEvent.click(digit["3"]);
+    fireEvent.click(erase);
+
+    expect(cell[1]).toHaveTextContent("");
+  });
+
+  test("should erase a note cell", () => {
+    const { cell, digit, erase, notes } = TEST_GAME;
+
+    fireEvent.click(notes);
+    fireEvent.click(cell[1]);
+    fireEvent.click(digit["3"]);
+    fireEvent.click(digit["5"]);
+
+    fireEvent.click(erase);
+
+    expect(cell[1]).toHaveTextContent("");
+  });
+
+  test("should work with undo", () => {
+    const { cell, digit, erase, undo } = TEST_GAME;
+
+    fireEvent.click(cell[1]);
+    fireEvent.click(digit["3"]);
+    fireEvent.click(erase);
+
+    fireEvent.click(undo);
+
+    expect(cell[1]).toHaveTextContent("3");
   });
 });

--- a/web-app/src/components/game/game.test.tsx
+++ b/web-app/src/components/game/game.test.tsx
@@ -1,7 +1,13 @@
 import { Digit } from "@/shared/digit";
 import { Puzzle } from "@/shared/puzzle";
 import "@testing-library/jest-dom/matchers";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, test } from "vitest";
 import { Game } from "./game";
 
@@ -62,7 +68,7 @@ describe("Game", () => {
   test("should have initial empty", () => {
     const { cell } = TEST_GAME;
 
-    expect(cell[2]).toHaveTextContent("");
+    expect(digits(cell[2])).toHaveLength(0);
   });
 });
 
@@ -93,7 +99,7 @@ describe("digit toggled 'off'", () => {
 
     fireEvent.click(digit["3"]);
 
-    expect(cell[1]).toHaveTextContent("");
+    expect(digits(cell[1])).toHaveLength(0);
   });
 
   test("should replace existing proposed cell with different digit", () => {
@@ -114,7 +120,7 @@ describe("digit toggled 'off'", () => {
     fireEvent.click(cell[2]);
     fireEvent.click(digit["1"]);
 
-    expect(cell[2]).toHaveTextContent("");
+    expect(digits(cell[2])).toHaveLength(0);
   });
 });
 
@@ -181,7 +187,7 @@ describe("digit toggled 'on'", () => {
     fireEvent.click(cell[1]);
     fireEvent.click(cell[1]);
 
-    expect(cell[1]).toHaveTextContent("");
+    expect(digits(cell[1])).toHaveLength(0);
   });
 
   test("should not allow new proposed digit to clash with siblings", () => {
@@ -190,7 +196,7 @@ describe("digit toggled 'on'", () => {
     fireEvent.click(digit["4"]);
     fireEvent.click(cell[2]);
 
-    expect(cell[2]).toHaveTextContent("");
+    expect(digits(cell[2])).toHaveLength(0);
   });
 
   test("should not allow replacing proposed digit clashing with siblings", () => {
@@ -288,7 +294,7 @@ describe("notes toggled: on, digit toggled: on", () => {
     fireEvent.click(digit["5"]);
     fireEvent.click(cell[1]);
 
-    expect(cell[1]).toHaveTextContent("");
+    expect(digits(cell[1])).toHaveLength(0);
   });
 
   test("clicking on given cell has no");
@@ -378,7 +384,7 @@ describe("prune proposed from sibling notes", () => {
     fireEvent.click(digit["3"]);
     fireEvent.click(digit["7"]);
 
-    expect(cell[1]).toHaveTextContent("");
+    expect(digits(cell[1])).toHaveLength(0);
   });
 
   test("should prune multiple siblings", () => {
@@ -400,7 +406,7 @@ describe("prune proposed from sibling notes", () => {
     expect(cell[1]).toHaveTextContent("5");
     expect(cell[1]).not.toHaveTextContent("3");
 
-    expect(cell[5]).toHaveTextContent("");
+    expect(digits(cell[5])).toHaveLength(0);
   });
 
   test("should not prune unaffected note", () => {
@@ -429,7 +435,7 @@ describe("undo changes", () => {
 
     fireEvent.click(undo);
 
-    expect(cell[1]).toHaveTextContent("");
+    expect(digits(cell[1])).toHaveLength(0);
   });
 
   test("should undo proposed cell", () => {
@@ -440,7 +446,7 @@ describe("undo changes", () => {
 
     fireEvent.click(undo);
 
-    expect(cell[1]).toHaveTextContent("");
+    expect(digits(cell[1])).toHaveLength(0);
   });
 
   test("should undo second proposed digit", () => {
@@ -517,7 +523,7 @@ describe("undo changes", () => {
   });
 });
 
-describe.only("erase toggled: off", () => {
+describe("erase", () => {
   test("should not erase given cell", () => {
     const { cell, erase } = TEST_GAME;
 
@@ -535,7 +541,7 @@ describe.only("erase toggled: off", () => {
     fireEvent.click(digit["3"]);
     fireEvent.click(erase);
 
-    expect(cell[1]).toHaveTextContent("");
+    expect(digits(cell[1])).toHaveLength(0);
   });
 
   test("should erase a note cell", () => {
@@ -548,7 +554,7 @@ describe.only("erase toggled: off", () => {
 
     fireEvent.click(erase);
 
-    expect(cell[1]).toHaveTextContent("");
+    expect(digits(cell[1])).toHaveLength(0);
   });
 
   test("should work with undo", () => {
@@ -561,5 +567,53 @@ describe.only("erase toggled: off", () => {
     fireEvent.click(undo);
 
     expect(cell[1]).toHaveTextContent("3");
+  });
+
+  test("should erase multiple cells when toggled: on", async () => {
+    const { cell, digit, erase } = TEST_GAME;
+
+    fireEvent.click(digit["9"]);
+    fireEvent.click(cell[23]);
+    fireEvent.click(cell[17]);
+    fireEvent.click(digit["9"]);
+
+    fireEvent.click(erase);
+
+    fireEvent.click(cell[17]);
+
+    expect(digits(cell[17])).toHaveLength(0);
+
+    fireEvent.click(cell[0]);
+
+    await waitFor(() => {
+      expect(cell[0]).toHaveTextContent("9");
+
+      fireEvent.click(cell[23]);
+
+      expect(digits(cell[23])).toHaveLength(0);
+    });
+  });
+
+  test("toggling notes on should toggle off erase", () => {
+    const { cell, digit, erase, notes } = TEST_GAME;
+
+    fireEvent.click(erase);
+
+    fireEvent.click(notes);
+    fireEvent.click(cell[3]);
+    fireEvent.click(digit["3"]);
+
+    expect(cell[3]).toHaveTextContent("3");
+  });
+
+  test("should toggle Erase: off when a digit is toggled: on", () => {
+    const { cell, digit, erase } = TEST_GAME;
+
+    fireEvent.click(erase);
+
+    fireEvent.click(digit["5"]);
+    fireEvent.click(cell[1]);
+
+    expect(cell[1]).toHaveTextContent("5");
   });
 });

--- a/web-app/src/components/game/game.tsx
+++ b/web-app/src/components/game/game.tsx
@@ -2,13 +2,12 @@ import { cn } from "@/lib/utils";
 import { Cell, siblingsOf } from "@/shared/cell";
 import { DIGITS, Digit } from "@/shared/digit";
 import { Puzzle } from "@/shared/puzzle";
-import { useEffect, useReducer, useState } from "react";
+import { useEffect, useReducer } from "react";
 import { gameReducer, setup } from "./game_reducer";
 import { ToggleableButton } from "./toggleable_button";
 
 function Game({ puzzle }: { puzzle: Puzzle }) {
   const [state, dispatch] = useReducer(gameReducer, puzzle, setup);
-  const [eraseMode, setEraseMode] = useState(false);
 
   useEffect(() => {
     if (state.notification) {
@@ -24,6 +23,10 @@ function Game({ puzzle }: { puzzle: Puzzle }) {
 
   const handleDigitClick = (digit: Digit) => {
     dispatch({ type: "digit_button_clicked", payload: { digit } });
+  };
+
+  const handleEraseClick = () => {
+    dispatch({ type: "erase_button_clicked" });
   };
 
   const handleNotesClick = () => {
@@ -64,8 +67,8 @@ function Game({ puzzle }: { puzzle: Puzzle }) {
             className="flex h-12 basis-1/4 items-center justify-around rounded bg-zinc-300 text-2xl font-semibold text-slate-800 shadow-sm 
             xl:order-4 xl:h-16 xl:w-44"
             toggledClassName="bg-zinc-500 text-white"
-            toggled={eraseMode}
-            onClick={() => setEraseMode((_) => !eraseMode)}
+            toggled={state.eraseToggled}
+            onClick={handleEraseClick}
           >
             Erase
           </ToggleableButton>
@@ -119,6 +122,11 @@ function Game({ puzzle }: { puzzle: Puzzle }) {
                     "bg-red-300":
                       state.notification?.index === i &&
                       state.notification?.reason === "clash",
+                  },
+                  {
+                    "bg-sky-200":
+                      state.notification?.index === i &&
+                      state.notification?.reason === "given",
                   },
                 )}
               >

--- a/web-app/src/components/game/game.tsx
+++ b/web-app/src/components/game/game.tsx
@@ -11,7 +11,9 @@ function Game({ puzzle }: { puzzle: Puzzle }) {
 
   useEffect(() => {
     if (state.notification) {
-      setTimeout(handleNotification, 300);
+      const notification = state.notification;
+
+      setTimeout(handleNotification, notification.delay);
     }
   }, [state.notification]);
 
@@ -126,7 +128,8 @@ function Game({ puzzle }: { puzzle: Puzzle }) {
                   {
                     "bg-sky-200":
                       state.notification?.index === i &&
-                      state.notification?.reason === "given",
+                      (state.notification?.reason === "empty" ||
+                        state.notification?.reason === "given"),
                   },
                 )}
               >

--- a/web-app/src/components/game/game_reducer.ts
+++ b/web-app/src/components/game/game_reducer.ts
@@ -5,7 +5,8 @@ import { Stack } from "@/shared/stack";
 
 type CellNotification = {
   index: number;
-  reason: Cell[keyof Cell] | "clash";
+  reason: Cell[keyof Cell] | "clash" | "empty";
+  delay: number;
 };
 
 type GameState = {
@@ -78,7 +79,7 @@ function updateAndPrune(
   if (siblingDigits.has(digit)) {
     return {
       ...state,
-      notification: { index, reason: "clash" },
+      notification: { index, reason: "clash", delay: 300 },
     };
   }
 
@@ -132,7 +133,7 @@ function fillCell(state: GameState, index: number, digit: Digit): GameState {
       // trying to put notes in a proposed cell should briefly flash gray
       return {
         ...state,
-        notification: { index, reason: "proposed" },
+        notification: { index, reason: "proposed", delay: 200 },
       };
     }
 
@@ -193,11 +194,11 @@ function eraseCell(state: GameState, index: number): GameState {
 
   if (selectedCell.kind === "given") {
     // We can't erase given cells, notify user
-    return { ...state, notification: { index, reason: "given" } };
+    return { ...state, notification: { index, reason: "given", delay: 200 } };
   }
 
   if (selectedCell.kind === "note" && selectedCell.digits.size === 0) {
-    return state;
+    return { ...state, notification: { index, reason: "empty", delay: 200 } };
   }
 
   const updatedCells: Cell[] = state.cells.map((cell, i) => {
@@ -227,14 +228,21 @@ function gameReducer(state: GameState, action: GameAction): GameState {
     if (state.selectedIndex) {
       return eraseCell(state, state.selectedIndex);
     }
-    return state;
+
+    const eraseToggled = !state.eraseToggled;
+
+    const toggledDigit = eraseToggled ? undefined : state.toggledDigit;
+
+    return { ...state, toggledDigit, eraseToggled, highlightDigit: undefined };
   }
 
   if (action.type === "notes_button_clicked") {
-    return {
-      ...state,
-      notesToggled: !state.notesToggled,
-    };
+    // when notes have been toggled on, untoggle the erase button
+    const notesToggled = !state.notesToggled;
+
+    const eraseToggled = notesToggled ? false : state.eraseToggled;
+
+    return { ...state, notesToggled, eraseToggled };
   }
 
   if (action.type === "undo_button_clicked") {
@@ -276,12 +284,17 @@ function gameReducer(state: GameState, action: GameAction): GameState {
       ...state,
       toggledDigit: action.payload.digit,
       highlightDigit: action.payload.digit,
+      eraseToggled: false,
     };
   }
 
   if (action.type === "cell_clicked") {
     if (state.toggledDigit) {
       return fillCell(state, action.payload.index, state.toggledDigit);
+    }
+
+    if (state.eraseToggled) {
+      return eraseCell(state, action.payload.index);
     }
 
     if (state.selectedIndex === action.payload.index) {

--- a/web-app/src/components/game/game_reducer.ts
+++ b/web-app/src/components/game/game_reducer.ts
@@ -133,7 +133,7 @@ function fillCell(state: GameState, index: number, digit: Digit): GameState {
       // trying to put notes in a proposed cell should briefly flash gray
       return {
         ...state,
-        notification: { index, reason: "proposed", delay: 200 },
+        notification: { index, reason: "proposed", delay: 100 },
       };
     }
 
@@ -194,11 +194,11 @@ function eraseCell(state: GameState, index: number): GameState {
 
   if (selectedCell.kind === "given") {
     // We can't erase given cells, notify user
-    return { ...state, notification: { index, reason: "given", delay: 200 } };
+    return { ...state, notification: { index, reason: "given", delay: 100 } };
   }
 
   if (selectedCell.kind === "note" && selectedCell.digits.size === 0) {
-    return { ...state, notification: { index, reason: "empty", delay: 200 } };
+    return { ...state, notification: { index, reason: "empty", delay: 100 } };
   }
 
   const updatedCells: Cell[] = state.cells.map((cell, i) => {


### PR DESCRIPTION
Implemented Erase functionality as per issue #32.

Erase button is not disabled when all non-given cells are empty.  Instead, a notification is used to indicate no action was taken on the clicked cell.

Other implemented behaviour:

- when Erase is toggled on, clicking Notes toggles Erase off
- when Erase is toggled on, any toggled digit is toggled off
- when Erase is toggled on, any highlight Digit is deselected