### PR TITLE
Fix/36 erase behaviour

### DIFF
--- a/web-app/src/app.tsx
+++ b/web-app/src/app.tsx
@@ -9,7 +9,7 @@ function App() {
   const [level, setLevel] = useState<Level>(LEVELS[0]);
 
   useEffect(() => {
-    console.log(`User wants to play a ${level} game`);
+    console.log(`Difficulty ${level} chosen`);
   }, [level]);
 
   const handleChange = (value: string) => {

--- a/web-app/src/components/game/game.test.tsx
+++ b/web-app/src/components/game/game.test.tsx
@@ -606,12 +606,26 @@ describe("erase", () => {
     expect(cell[3]).toHaveTextContent("3");
   });
 
-  test("should toggle Erase: off when a digit is toggled: on", () => {
+  test("should toggle Erase off when a digit is toggled: on", () => {
     const { cell, digit, erase } = TEST_GAME;
 
     fireEvent.click(erase);
 
     fireEvent.click(digit["5"]);
+    fireEvent.click(cell[1]);
+
+    expect(cell[1]).toHaveTextContent("5");
+  });
+
+  test("should not toggle Erase on when trying to erase a given cell", () => {
+    const { cell, digit, erase } = TEST_GAME;
+
+    fireEvent.click(cell[1]);
+    fireEvent.click(digit["5"]);
+
+    fireEvent.click(cell[0]);
+    fireEvent.click(erase);
+
     fireEvent.click(cell[1]);
 
     expect(cell[1]).toHaveTextContent("5");


### PR DESCRIPTION
Fixed Erase button behaviour as per Issue #36.

Selected index conditions now test for being not/equal to 'undefined' rather than being truthy.

A Selected index value of 0 is valid buy caused issues when Cell-0 was being referenced.